### PR TITLE
Fix: Distinguish PREFIX-SUFFIX from INPUT-OUTPUT PAIRS in 02 Molecules diagram

### DIFF
--- a/00_foundations/02_molecules_context.md
+++ b/00_foundations/02_molecules_context.md
@@ -69,24 +69,24 @@ The molecular approach typically achieves:
 The structure of your molecular context matters greatly. Here are common patterns:
 
 ```
-┌───────────────────┐  ┌───────────────────┐  ┌───────────────────┐
-│ PREFIX-SUFFIX     │  │ INPUT-OUTPUT PAIRS │  │ CHAIN-OF-THOUGHT  │
-├───────────────────┤  ├───────────────────┤  ├───────────────────┤
-│ <instruction>     │  │ <instruction>     │  │ <instruction>     │
-│                   │  │                   │  │                   │
-│ Input: <example1> │  │ Input: <example1> │  │ Input: <example1> │
-│ Output: <result1> │  │ Output: <result1> │  │ Thinking: <step1> │
-│                   │  │                   │  │         <step2>   │
-│ Input: <example2> │  │ Input: <example2> │  │ Output: <result1> │
-│ Output: <result2> │  │ Output: <result2> │  │                   │
-│                   │  │                   │  │ Input: <example2> │
-│ Input: <new_input>│  │ Input: <new_input>│  │ Thinking: <step1> │
-│ Output:           │  │ Output:           │  │         <step2>   │
-└───────────────────┘  └───────────────────┘  │ Output: <result2> │
-                                              │                   │
-                                              │ Input: <new_input>│
-                                              │ Thinking:         │
-                                              └───────────────────┘
+┌─────────────────────────┐  ┌───────────────────┐  ┌───────────────────┐
+│ PREFIX-SUFFIX           │  │ INPUT-OUTPUT PAIRS│  │ CHAIN-OF-THOUGHT  │
+├─────────────────────────┤  ├───────────────────┤  ├───────────────────┤
+│ <instruction>           │  │ <instruction>     │  │ <instruction>     │
+│                         │  │                   │  │                   │
+│ <example1> → <result1>  │  │ Input: <example1> │  │ Input: <example1> │
+│                         │  │ Output: <result1> │  │ Thinking: <step1> │
+│ <example2> → <result2>  │  │                   │  │           <step2> │
+│                         │  │ Input: <example2> │  │ Output: <result1> │
+│ <new_input> →           │  │ Output: <result2> │  │                   │
+└─────────────────────────┘  │                   │  │ Input: <example2> │
+                             │ Input: <new_input>│  │ Thinking: <step1> │
+                             │ Output:           │  │           <step2> │
+                             └───────────────────┘  │ Output: <result2> │
+                                                    │                   │
+                                                    │ Input: <new_input>│
+                                                    │ Thinking:         │
+                                                    └───────────────────┘
 ```
 
 Each template has strengths for different tasks:


### PR DESCRIPTION
## Problem
The current diagram in "Designing Effective Molecular Templates" shows identical examples for both PREFIX-SUFFIX and INPUT-OUTPUT PAIRS patterns, making it difficult to understand the difference between them.

## Solution
Updated the PREFIX-SUFFIX example to use arrow notation (`→`) instead of explicit Input/Output labels, which better demonstrates the actual difference between these two patterns:

- **PREFIX-SUFFIX**: Uses compact format with arrows (e.g., `<example1> → <result1>`)
- **INPUT-OUTPUT PAIRS**: Uses explicit labels (e.g., `Input: <example1>` / `Output: <result1>`)

## Changes
- Modified the PREFIX-SUFFIX column to show arrow notation
- Adjusted box widths for proper alignment
- Kept INPUT-OUTPUT PAIRS and CHAIN-OF-THOUGHT patterns unchanged

This change makes the distinction between the patterns clearer for learners following the context engineering guide.


Cheers