### PR TITLE
Fix token-quality curve: correct direction of quality improvement

### DIFF
--- a/00_foundations/01_atoms_prompting.md
+++ b/00_foundations/01_atoms_prompting.md
@@ -127,19 +127,17 @@ This implicit knowledge gives us a foundation, but it's unreliable and varies be
 For many tasks, we observe a power law relationship between context tokens and output quality:
 
 ```
-    Quality
+Quality
       ▲
-      │
+      │                        •
+      │                    •       •
+      │                •               •
+      │            •                       •
+      │        •                               •
       │    •
-      │        •
-      │            •
-      │                •
-      │                    •
-      │                        •         •         •
-      │                             
+      │•
       └───────────────────────────────────────────► Tokens
-                                      
-          [Maximum ROI Zone]       [Diminishing Returns]
+          [Poor Start]  [Maximum ROI]  [Diminishing Returns]
 ```
 
 The critical insight: there's a "maximum ROI zone" where adding just a few tokens yields dramatic quality improvements as well as "diminishing returns", where adding more tokens instead degrades performance.


### PR DESCRIPTION
Summary

  Corrected an inverted graph in 00_foundations/01_atoms_prompting.md that was displaying the relationship between complexity and response quality incorrectly.

  Changes Made

  - Fixed the visual representation in the Token-Quality Curve graph to properly show the power law relationship between context tokens and output quality
  - Ensured the graph accurately depicts the "maximum ROI zone" and "diminishing returns" phases

  Context

  The original graph was displaying an inverted relationship that contradicted the documented power law principle where adding context tokens initially yields dramatic quality improvements before entering
  diminishing returns.

  Type of Contribution

  - Documentation fix
  - Visual asset correction

  Alignment with Project Philosophy

  This fix aligns with our core principles of:
  - Transparency: Ensuring visual representations accurately convey the concepts
  - Progressive Complexity: Maintaining clear foundational understanding in the 00_foundations layer
  - Visual Standards: Providing clear, informative diagrams

  Checklist

  - Change aligns with existing documentation style
  - Visual representation is accurate and clear
  - Maintains consistency with project's biological metaphor approach
  - No impact on other documentation sections

<img width="746" height="484" alt="Screenshot 2025-08-13 173112" src="https://github.com/user-attachments/assets/e0cc7071-8406-420f-8663-41cd14b03039" />

<img width="1061" height="453" alt="Screenshot 2025-08-13 173215" src="https://github.com/user-attachments/assets/ef1eb520-4d00-451c-ae3d-a247f795be79" />

