### PR TITLE
Fixing simple reference mistake

### DIFF
--- a/00_foundations/04_organs_applications.md
+++ b/00_foundations/04_organs_applications.md
@@ -971,7 +971,7 @@ These capabilities open up entirely new possibilities for AI applications.
 
 You've now completed the foundations series, exploring the complete progression from atoms to organs. From here, you can:
 
-1. Dive into the hands-on guides in `10_guides_zero_to_one/` to implement these concepts
+1. Dive into the hands-on guides in `10_guides_zero_to_hero/` to implement these concepts
 2. Explore the reusable templates in `20_templates/` for quick implementation
 3. Study the complete examples in `30_examples/` to see these principles in action
 4. Reference the detailed documentation in `40_reference/` for deeper understanding


### PR DESCRIPTION
The `10_guides_zero_to_one` directory doesn't exist. It was probably renamed to `10_guides_zero_to_hero` recently.